### PR TITLE
Hotfix for actions

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -8,10 +8,9 @@ on:
       - "src/**"
     branches: 
       - main
-      - staging
-      - dev/examples
-      - dev/new-architecture
-      - dev/actions
+      - examples
+      - dev/*
+      - actions
   pull_request:
     paths:
       - ".github/workflows/compile-examples.yml"
@@ -20,7 +19,6 @@ on:
     branches: 
       - main
       - staging
-      - dev/*
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (stm32duino).
     - cron: "0 8 * * TUE"
@@ -54,7 +52,7 @@ jobs:
             - name: arduino:avr
           cli-compile-flags: |
             - --warnings="default"
-      - name: Split string using awk
+      - name: Transform fqbn with awk
         id: get_fqbn
         run: |
           fqbn=$(echo "${{ matrix.fqbn }}" | awk 'gsub(/:/, "_")')


### PR DESCRIPTION
Логика веток:
- `main`- **не пушим**, только PR. Работающая версия, весь заявленный функционал реализован. PR будет одобрен только после прохождения автоматизированных тестов(компиляция+сборка на основные платформы)
- `staging` - **не пушим**, только PR. Компилируется, собирается. Могут быть интеграционные косяки. Не весь функционал может быть реализован. PR будет одобрен только после прохождения автоматизированных тестов(компиляция+сборка на основные платформы)
- `examples` - обновление/дополнение/исправление примеров(папка `examples/` в корне репозитория) для Arduino IDE. CI/CD триггерится каждым обновлением ветки.
- `actions` - обновление/дополнение/исправление скриптов `CI/CD` на GitHub
- `dev/*` - разработка чего-то б**о**льшего, чем ~~вы сами~~  фича/исправление. Если понимаете, что работаете над чем-то, что требует нескольких итераций или длительного срока разработки. Чтобы не засорять `staging`. CI/CD триггерится каждым обновлением ветки.
- `<своё название>` - просто ветка. CI/CD нет. Ограничений нет. Можно экспериментировать, ломать, чинить. 

</br>

- `dev/new-architecture` - временная ветка перехода на новую архитектуру библиотеки. 