### PR TITLE
Исправлена компиляция внутрениих .cpp 

### DIFF
--- a/src/AK8963.cpp
+++ b/src/AK8963.cpp
@@ -1,9 +1,10 @@
-#include "AK8963.h"
-#include "Adapter/System.h"
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "AK8963.h"
+#include "Adapter/System.h"
+#include "Device/I2CDevice.h"
 
 namespace IntroSatLib {
 

--- a/src/Accelerometer.cpp
+++ b/src/Accelerometer.cpp
@@ -1,8 +1,9 @@
-#include "Accelerometer.h"
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "Accelerometer.h"
+#include "Device/I2CDevice.h"
 
 namespace IntroSatLib {
 

--- a/src/Adapter/ARDUINO/ARDUINO_I2C.cpp
+++ b/src/Adapter/ARDUINO/ARDUINO_I2C.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/I2C.h"
 
 //#define ARDUINO

--- a/src/Adapter/ARDUINO/ARDUINO_System.cpp
+++ b/src/Adapter/ARDUINO/ARDUINO_System.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/System.h"
 
 #ifdef ARDUINO

--- a/src/Adapter/ARDUINO/ARDUINO_UART.cpp
+++ b/src/Adapter/ARDUINO/ARDUINO_UART.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/UART.h"
 
 #if defined(ARDUINO) // If HAL SPI is enabled and no Arduino framework

--- a/src/Adapter/GPIO.h
+++ b/src/Adapter/GPIO.h
@@ -18,7 +18,7 @@
 	#if defined(AVR)
 	/************** AVR  **************/
 		//  This is not yet supported, but it is here for future reference.
-		//  AVR-series in Arduino IDE
+		//  AVR-series outside Arduino IDE
 		#error "Bare AVR outside of Arduino IDE is not yet supported"
 
 	#elif defined(USE_HAL_DRIVER) // TODO Change to more reusable symbol
@@ -47,10 +47,10 @@
 
 	#else
 	/************ UNKNOWN ************/
-	//#ifndef INTROSATLIB_INTERNAL
-		#error "Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros."
-		#error "Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support."
-	//#endif
+		#ifndef INTROSATLIB_INTERNAL
+			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
+			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
+		#endif
 	#endif
 #endif /* ARDUINO */
 
@@ -93,9 +93,6 @@ public:
 
 } /* namespace intefaces */
 } /* namespace IntroSatLib */
-
-
-
 
 
 #endif /* ISL_GPIO_ENABLED */

--- a/src/Adapter/GPIO.h
+++ b/src/Adapter/GPIO.h
@@ -36,7 +36,7 @@
 			#define ISL_GPIO_ENABLED
 			namespace IntroSatLib::interfaces {using GPIO_HANDLE_TYPE = GPIO_TypeDef;}
 
-		#elif !defined(INTROSATLIB_INTERNAL)
+		#elif !defined(ISL_INTERNAL)
 			#error "GPIO not enabled as part of HAL"
 		#endif
 
@@ -47,7 +47,7 @@
 
 	#else
 	/************ UNKNOWN ************/
-		#ifndef INTROSATLIB_INTERNAL
+		#ifndef ISL_INTERNAL
 			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
 			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
 		#endif

--- a/src/Adapter/I2C.h
+++ b/src/Adapter/I2C.h
@@ -21,7 +21,7 @@
 	#if defined(AVR)
 	/************** AVR  **************/
 		//  This is not yet supported, but it is here for future reference.
-		//  AVR-series in Arduino IDE
+		//  AVR-series outside Arduino IDE
 		#error "Bare AVR outside of Arduino IDE is not yet supported"
 
 	#elif defined(USE_HAL_DRIVER) // TODO Change to more reusable symbol
@@ -50,19 +50,15 @@
 
 	#else
 	/************ UNKNOWN ************/
-	//#ifndef INTROSATLIB_INTERNAL
-		#error "Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros."
-		#error "Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support."
-	//#endif
+		#ifndef INTROSATLIB_INTERNAL
+			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
+			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
+		#endif
 	#endif
 #endif /* ARDUINO */
 
 
 #ifdef ISL_I2C_ENABLED
-#define I2C_ENABLED
-
-//#include <array>
-
 
 #define ASSERT_I2C_HAVE() \
 if(!_hi2c) { \

--- a/src/Adapter/I2C.h
+++ b/src/Adapter/I2C.h
@@ -39,7 +39,7 @@
 			#define	ISL_I2C_ENABLED
 			namespace IntroSatLib::interfaces {using I2C_HANDLE_TYPE = I2C_HandleTypeDef;}
 
-		#elif !defined(INTROSATLIB_INTERNAL)
+		#elif !defined(ISL_INTERNAL)
 			#error "I2C not enabled as part of HAL"
 		#endif
 
@@ -50,7 +50,7 @@
 
 	#else
 	/************ UNKNOWN ************/
-		#ifndef INTROSATLIB_INTERNAL
+		#ifndef ISL_INTERNAL
 			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
 			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
 		#endif

--- a/src/Adapter/INTERFACE.template
+++ b/src/Adapter/INTERFACE.template
@@ -41,7 +41,7 @@
 		#ifdef HAL_<INTERFACE>_MODULE_ENABLED
 			// define STM32-specific handle type for <INTERFACE>
 			namespace IntroSatLib::interfaces {using <INTERFACE>_HANDLE_TYPE = <INTERFACE>_HandleTypeDef;}
-		#elif !defined(INTROSATLIB_INTERNAL)
+		#elif !defined(ISL_INTERNAL)
 			#error "<INTERFACE> not enabled as part of HAL"
 		#endif
 
@@ -50,7 +50,7 @@
 		// #error "AMUR not yet supported"
 	/************ UNKNOWN ************/
 	#else
-	// #ifndef INTROSATLIB_INTERNAL
+	// #ifndef ISL_INTERNAL
 		#error "Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros."
 		#error "Currently supported systems are: stm32, stm32duino. AVR planned for future support."
 	// #endif

--- a/src/Adapter/SPI.h
+++ b/src/Adapter/SPI.h
@@ -38,7 +38,7 @@
 			// define STM32-specific handle type for SPI
 			#define ISL_SPI_ENABLED
 			namespace IntroSatLib::interfaces {using SPI_HANDLE_TYPE = SPI_HandleTypeDef;}
-		#elif !defined(INTROSATLIB_INTERNAL)
+		#elif !defined(ISL_INTERNAL)
 			#error "SPI not enabled as part of HAL"
 		#endif
 
@@ -47,7 +47,7 @@
 		// #error "AMUR not yet supported"
 	/************ UNKNOWN ************/
 	#else
-		#ifndef INTROSATLIB_INTERNAL
+		#ifndef ISL_INTERNAL
 			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
 			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
 		#endif

--- a/src/Adapter/SPI.h
+++ b/src/Adapter/SPI.h
@@ -21,8 +21,8 @@
 	#if defined(AVR)
 	/************** AVR  **************/
 		//  This is not yet supported, but it is here for future reference.
-		//  AVR-series in Arduino IDE
-		#error "AVR not yet supported"
+		//  AVR-series outside Arduino IDE
+		#error "Bare AVR outside of Arduino IDE is not yet supported"
 
 	#elif defined(USE_HAL_DRIVER)
 	/*****  STM32 and stm32duino ******/
@@ -47,10 +47,10 @@
 		// #error "AMUR not yet supported"
 	/************ UNKNOWN ************/
 	#else
-	// #ifndef INTROSATLIB_INTERNAL
-		#error "Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros."
-		#error "Currently supported systems are: stm32, stm32duino. AVR planned for future support."
-	// #endif
+		#ifndef INTROSATLIB_INTERNAL
+			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
+			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
+		#endif
 	#endif
 #endif
 

--- a/src/Adapter/STM32/STM32_I2C.cpp
+++ b/src/Adapter/STM32/STM32_I2C.cpp
@@ -1,5 +1,5 @@
 
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/I2C.h"
 
 #if defined(HAL_I2C_MODULE_ENABLED) && !defined(ARDUINO)

--- a/src/Adapter/STM32/STM32_SPI.cpp
+++ b/src/Adapter/STM32/STM32_SPI.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/SPI.h"
 
 #if defined(HAL_SPI_MODULE_ENABLED) && !defined(ARDUINO) // If HAL SPI is enabled and no Arduino framework

--- a/src/Adapter/STM32/STM32_System.cpp
+++ b/src/Adapter/STM32/STM32_System.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/System.h"
 
 #if defined(HAL_I2C_MODULE_ENABLED) && !defined(ARDUINO)

--- a/src/Adapter/STM32/STM32_UART.cpp
+++ b/src/Adapter/STM32/STM32_UART.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 #include "Adapter/UART.h"
 
 #if defined(HAL_UART_MODULE_ENABLED) && !defined(ARDUINO) // If HAL SPI is enabled and no Arduino framework

--- a/src/Adapter/System.h
+++ b/src/Adapter/System.h
@@ -39,10 +39,10 @@
 	#else
 	/************ UNKNOWN ************/
 
-//	#ifndef INTROSATLIB_INTERNAL
-		#error "Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros."
-		#error "Currently supported systems are: stm32, stm32duino. AVR planned for future support."
-//	#endif
+		#ifndef INTROSATLIB_INTERNAL
+			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
+			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
+		#endif
 	#endif
 #endif /* ARDUINO */
 

--- a/src/Adapter/System.h
+++ b/src/Adapter/System.h
@@ -39,7 +39,7 @@
 	#else
 	/************ UNKNOWN ************/
 
-		#ifndef INTROSATLIB_INTERNAL
+		#ifndef ISL_INTERNAL
 			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
 			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
 		#endif

--- a/src/Adapter/UART.h
+++ b/src/Adapter/UART.h
@@ -10,6 +10,7 @@
 /*********************************/
 	#include "Arduino.h"
 	#include <HardwareSerial.h>
+	#define	ISL_UART_ENABLED
 	namespace IntroSatLib::interfaces {using UART_HANDLE_TYPE = HardwareSerial;}
 
 #else
@@ -20,8 +21,8 @@
 	#if defined(AVR)
 	/************** AVR  **************/
 		//  This is not yet supported, but it is here for future reference.
-		//  AVR-series in Arduino IDE
-		#error "AVR not yet supported"
+		//  AVR-series outside Arduino IDE
+		#error "Bare AVR outside of Arduino IDE is not yet supported"
 
 	#elif defined(USE_HAL_DRIVER)
 	/*****  STM32 and stm32duino ******/
@@ -35,6 +36,7 @@
 
 		#ifdef HAL_UART_MODULE_ENABLED
 			// define STM32-specific handle type for UART
+			#define	ISL_UART_ENABLED
 			namespace IntroSatLib::interfaces {using UART_HANDLE_TYPE = UART_HandleTypeDef;}
 		#elif !defined(INTROSATLIB_INTERNAL)
 			#error "UART not enabled as part of HAL"
@@ -45,15 +47,15 @@
 		// #error "AMUR not yet supported"
 	/************ UNKNOWN ************/
 	#else
-	// #ifndef INTROSATLIB_INTERNAL
-		#error "Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros."
-		#error "Currently supported systems are: stm32, stm32duino. AVR planned for future support."
-	// #endif
+		#ifndef INTROSATLIB_INTERNAL
+			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
+			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
+		#endif
 	#endif
 #endif
 
-// #ifdef UART_HANDLE_TYPE
-#define UART_ENABLED
+#ifdef ISL_UART_ENABLED
+
 #include "Adapter/System.h"
 
 #define ASSERT_UART_HAVE() \
@@ -140,6 +142,6 @@ public:
 } /* namespace intefaces */
 } /* namespace IntroSatLib */
 
-// #endif /* UART_HANDLE_TYPE */
+#endif /* ISL_UART_ENABLED */
 
 #endif /* ADAPTER_UART_H_ */

--- a/src/Adapter/UART.h
+++ b/src/Adapter/UART.h
@@ -38,7 +38,7 @@
 			// define STM32-specific handle type for UART
 			#define	ISL_UART_ENABLED
 			namespace IntroSatLib::interfaces {using UART_HANDLE_TYPE = UART_HandleTypeDef;}
-		#elif !defined(INTROSATLIB_INTERNAL)
+		#elif !defined(ISL_INTERNAL)
 			#error "UART not enabled as part of HAL"
 		#endif
 
@@ -47,7 +47,7 @@
 		// #error "AMUR not yet supported"
 	/************ UNKNOWN ************/
 	#else
-		#ifndef INTROSATLIB_INTERNAL
+		#ifndef ISL_INTERNAL
 			#error Unsupported system: neither AVR/ARDUINO nor USE_HAL_DRIVER defined. Please check your platform macros.  \
 			 		Currently supported systems are: stm32 with HAL, stm32duino. AVR planned for future support.
 		#endif

--- a/src/Device/CC1101/CC1101.cpp
+++ b/src/Device/CC1101/CC1101.cpp
@@ -1,8 +1,10 @@
 #define INTROSATLIB_INTERNAL
-#include "CC1101.h"
+
 #include "Adapter/SPI.h"
 
 #ifdef ISL_SPI_ENABLED_NOT
+
+#include "CC1101.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/CC1101/CC1101.cpp
+++ b/src/Device/CC1101/CC1101.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/SPI.h"
 

--- a/src/Device/FlyWheel/BaseFlyWheel.cpp
+++ b/src/Device/FlyWheel/BaseFlyWheel.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/FlyWheel/BaseFlyWheel.cpp
+++ b/src/Device/FlyWheel/BaseFlyWheel.cpp
@@ -1,8 +1,11 @@
-#include "BaseFlyWheel.h"
+#define INTROSATLIB_INTERNAL
+
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "BaseFlyWheel.h"
+#include "Device/I2CDevice.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/FlyWheel/CoilFlyWheel.cpp
+++ b/src/Device/FlyWheel/CoilFlyWheel.cpp
@@ -1,7 +1,10 @@
-#include "CoilFlyWheel.h"
+#define INTROSATLIB_INTERNAL
+
 #include "Adapter/I2C.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "CoilFlyWheel.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/FlyWheel/CoilFlyWheel.cpp
+++ b/src/Device/FlyWheel/CoilFlyWheel.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/FlyWheel/MotorFlyWheel.cpp
+++ b/src/Device/FlyWheel/MotorFlyWheel.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/FlyWheel/MotorFlyWheel.cpp
+++ b/src/Device/FlyWheel/MotorFlyWheel.cpp
@@ -1,7 +1,10 @@
-#include "MotorFlyWheel.h"
+#define INTROSATLIB_INTERNAL
+
 #include "Adapter/I2C.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "MotorFlyWheel.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/I2CDevice.cpp
+++ b/src/Device/I2CDevice.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/I2CDevice.cpp
+++ b/src/Device/I2CDevice.cpp
@@ -1,5 +1,10 @@
-#include "I2CDevice.h"
+#define INTROSATLIB_INTERNAL
+
+#include "Adapter/I2C.h"
+
 #ifdef ISL_I2C_ENABLED
+
+#include "I2CDevice.h"
 namespace IntroSatLib {
 
 ISL_StatusTypeDef I2CDevice::IsReady() {

--- a/src/Device/IRCamera/IRCamera.cpp
+++ b/src/Device/IRCamera/IRCamera.cpp
@@ -1,4 +1,4 @@
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 #include "Adapter/System.h"

--- a/src/Device/IRCamera/IRCamera.cpp
+++ b/src/Device/IRCamera/IRCamera.cpp
@@ -1,9 +1,12 @@
-#include "IRCamera.h"
-#include "Adapter/System.h"
+#define INTROSATLIB_INTERNAL
+
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
+#include "Adapter/System.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "IRCamera.h"
+#include "Device/I2CDevice.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/LIS2MDL/LIS2MDL.cpp
+++ b/src/Device/LIS2MDL/LIS2MDL.cpp
@@ -4,13 +4,15 @@
  *  Created on: Nov 24, 2025
  *      Author: samsa
  */
+#define INTROSATLIB_INTERNAL
 
-#include "LIS2MDL.h"
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
-#include "Adapter/System.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "LIS2MDL.h"
+#include "Device/I2CDevice.h"
+#include "Adapter/System.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/LIS2MDL/LIS2MDL.cpp
+++ b/src/Device/LIS2MDL/LIS2MDL.cpp
@@ -4,7 +4,7 @@
  *  Created on: Nov 24, 2025
  *      Author: samsa
  */
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/LIS3MDL/LIS3MDL.cpp
+++ b/src/Device/LIS3MDL/LIS3MDL.cpp
@@ -4,7 +4,7 @@
  *  Created on: Mar 18, 2025
  *      Author: unflesh
  */
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/LIS3MDL/LIS3MDL.cpp
+++ b/src/Device/LIS3MDL/LIS3MDL.cpp
@@ -4,13 +4,15 @@
  *  Created on: Mar 18, 2025
  *      Author: unflesh
  */
+#define INTROSATLIB_INTERNAL
+
+#include "Adapter/I2C.h"
+
+#ifdef ISL_I2C_ENABLED
 
 #include "LIS3MDL.h"
 #include "Adapter/System.h"
-#include "Adapter/I2C.h"
 #include "Device/I2CDevice.h"
-
-#ifdef ISL_I2C_ENABLED
 
 namespace IntroSatLib {
 

--- a/src/Device/LM75A/LM75A.cpp
+++ b/src/Device/LM75A/LM75A.cpp
@@ -4,13 +4,15 @@
  *  Created on: Mar 6, 2025
  *      Author: Aleksey <TeaCupMe> Gilenko
  */
+#define INTROSATLIB_INTERNAL
 
-#include "LM75A.h"
 #include "Adapter/I2C.h"
-#include "Adapter/System.h"
-#include "Device/I2CDevice.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "LM75A.h"
+#include "Adapter/System.h"
+#include "Device/I2CDevice.h"
 
 namespace IntroSatLib {
 

--- a/src/Device/LM75A/LM75A.cpp
+++ b/src/Device/LM75A/LM75A.cpp
@@ -4,7 +4,7 @@
  *  Created on: Mar 6, 2025
  *      Author: Aleksey <TeaCupMe> Gilenko
  */
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/LSM6DS3/LSM6DS3.cpp
+++ b/src/Device/LSM6DS3/LSM6DS3.cpp
@@ -4,7 +4,7 @@
  *  Created on: Mar 17, 2025
  *      Author: Goldfor
  */
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Device/LSM6DS3/LSM6DS3.cpp
+++ b/src/Device/LSM6DS3/LSM6DS3.cpp
@@ -4,13 +4,15 @@
  *  Created on: Mar 17, 2025
  *      Author: Goldfor
  */
+#define INTROSATLIB_INTERNAL
+
+#include "Adapter/I2C.h"
+
+#ifdef ISL_I2C_ENABLED
 
 #include "LSM6DS3.h"
 #include "Adapter/System.h"
 #include "Device/I2CDevice.h"
-#include "stdint.h"
-
-#ifdef ISL_I2C_ENABLED
 
 namespace IntroSatLib {
 

--- a/src/Device/MS5611/MS5611.cpp
+++ b/src/Device/MS5611/MS5611.cpp
@@ -4,13 +4,15 @@
  *  Created on: Mar 10, 2025
  *      Author: unflesh
  */
+#define INTROSATLIB_INTERNAL
+
+#include "Adapter/I2C.h"
+
+#ifdef ISL_I2C_ENABLED
 
 #include "MS5611.h"
 #include "Adapter/System.h"
-#include "Adapter/I2C.h"
 #include "Device/I2CDevice.h"
-
-#ifdef ISL_I2C_ENABLED
 
 namespace IntroSatLib {
 

--- a/src/Device/MS5611/MS5611.cpp
+++ b/src/Device/MS5611/MS5611.cpp
@@ -4,7 +4,7 @@
  *  Created on: Mar 10, 2025
  *      Author: unflesh
  */
-#define INTROSATLIB_INTERNAL
+#define ISL_INTERNAL
 
 #include "Adapter/I2C.h"
 

--- a/src/Gyroscope.cpp
+++ b/src/Gyroscope.cpp
@@ -1,24 +1,16 @@
-#include "Gyroscope.h"
-#include "IntroSatLib_def.h"
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
 
 #ifdef ISL_I2C_ENABLED
 
+#include "Gyroscope.h"
+#include "IntroSatLib_def.h"
+#include "Device/I2CDevice.h"
+
 namespace IntroSatLib {
 
-//#ifndef ARDUINO
 Gyroscope::Gyroscope(const interfaces::I2C &i2c, uint8_t address): I2CDevice(new interfaces::I2C(i2c), address)
 {
 }
-//#else
-//Gyroscope::Gyroscope(TwoWire &hi2c, uint8_t address): I2CDevice(hi2c, address)
-//{
-//}
-//Gyroscope::Gyroscope(uint8_t address): I2CDevice(address)
-//{
-//}
-//#endif
 
 Gyroscope::Gyroscope(const Gyroscope &other): I2CDevice(other)
 {

--- a/src/ISL_Bootloader.h
+++ b/src/ISL_Bootloader.h
@@ -22,7 +22,7 @@
 #endif
 
 // raise warn if boot address is not set
-#if !defined(BOOT_ADDR) and !defined(INTROSATLIB_INTERNAL)
+#if !defined(BOOT_ADDR) and !defined(ISL_INTERNAL)
     // Looks like unsupported platform
 	#warning "IntroSatLib::EnterBootloader() not supported by selected package"
 	#warning "IntroSatLib::EnterBootloader() currently supports STM32F1xx, STM32F4xx, STM32H750xx."

--- a/src/LightSensor.cpp
+++ b/src/LightSensor.cpp
@@ -1,22 +1,15 @@
-#include "LightSensor.h"
 #include "Adapter/I2C.h"
-#include "Device/I2CDevice.h"
 
 #ifdef ISL_I2C_ENABLED
+
+#include "LightSensor.h"
+#include "Device/I2CDevice.h"
+
 namespace IntroSatLib {
 
-//#ifndef ARDUINO
 LightSensor::LightSensor(const interfaces::I2C &i2c, uint8_t address): I2CDevice(new interfaces::I2C(i2c), address)
 {
 }
-//#else
-//LightSensor::LightSensor(TwoWire &hi2c, uint8_t address): BaseDevice(hi2c, address)
-//{
-//}
-//LightSensor::LightSensor(uint8_t address): BaseDevice(address)
-//{
-//}
-//#endif
 
 LightSensor::LightSensor(const LightSensor &other): I2CDevice(other)
 {


### PR DESCRIPTION
Добавлен макрос ISL_INTERNAL, объявленный во всех .cpp файлах, работяющих с периферией. 

Если этот макрос объявлен при копиляции юнита, процесс компиляции заголовочного файла адаптера периферии не будет остановлен с ошибкой даже если периферия недоступна. 

 